### PR TITLE
Get rid of multiple data.data props

### DIFF
--- a/client/src/reducers/clientsSlice.js
+++ b/client/src/reducers/clientsSlice.js
@@ -12,7 +12,7 @@ export const fetchClients = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const res = await axios.get("/api/v1/clients");
-      return res.data.data.data;
+      return res.data.data;
     } catch (err) {
       return rejectWithValue(err.message);
     }
@@ -25,7 +25,7 @@ export const createClient = createAsyncThunk(
     try {
       const res = await axios.post("/api/v1/clients", { name: data });
 
-      return res.data.data.data;
+      return res.data.data;
     } catch (err) {
       return rejectWithValue(err.message);
     }

--- a/client/src/reducers/projectsSlice.js
+++ b/client/src/reducers/projectsSlice.js
@@ -12,7 +12,7 @@ export const fetchProjects = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const res = await axios.get(`/api/v1/projects`);
-      const projects = res.data.data.data;
+      const projects = res.data.data;
 
       const processedProjects = projects.map(project => {
         return { ...project, client: project.client.name };
@@ -31,7 +31,7 @@ export const fetchProject = createAsyncThunk(
     try {
       const res = await axios.get(`/api/v1/projects/${id}`);
 
-      return res.data.data.data;
+      return res.data.data;
     } catch (err) {
       return rejectWithValue(err.message);
     }
@@ -47,7 +47,7 @@ export const updateProject = createAsyncThunk(
         project.editedFields
       );
 
-      const updatedProject = res.data.data.data;
+      const updatedProject = res.data.data;
 
       const returnProject = {
         _id: updatedProject._id,
@@ -72,7 +72,7 @@ export const createProject = createAsyncThunk(
     try {
       const res = await axios.post("/api/v1/projects", project.values);
 
-      const newProject = res.data.data.data;
+      const newProject = res.data.data;
 
       const returnProject = {
         _id: newProject._id,

--- a/utils/crud.js
+++ b/utils/crud.js
@@ -19,7 +19,7 @@ const getAll = Model =>
     res.status(200).json({
       status: "success",
       results: docs.length,
-      data: { data: docs }
+      data: docs
     });
   });
 
@@ -41,7 +41,7 @@ const getOne = Model =>
 
     res.status(200).json({
       status: "success",
-      data: { data: doc }
+      data: doc
     });
   });
 
@@ -68,7 +68,7 @@ const updateOne = Model =>
 
     res.status(200).json({
       status: "success",
-      data: { data: doc }
+      data: doc
     });
   });
 
@@ -110,7 +110,7 @@ const createOne = Model =>
 
     res.status(201).json({
       status: "success",
-      data: { data: doc.toJSON() }
+      data: doc.toJSON()
     });
   });
 


### PR DESCRIPTION
There is an unnecessary level of deeply nested data.data.data props. Since I won't be sending object inside the original `data` prop, I decided that it can hold the returned data itself, hence no need for data.data.data.